### PR TITLE
Remove dependency on ag 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # Install
 
-This program requires Python 3.2+.
-For music playback, it uses the program `mpv`.
-These can be installed on OS X by using the following
-[Homebrew](http://brew.sh/) command
+This program requires [Python](https://www.python.org/) 3.2+. For music
+playback, it uses the program [`mpv`](https://mpv.io/), which can be installed
+on OS X by using the following [Homebrew](http://brew.sh/) command
 
 ```
 $ brew install python3 mpv
@@ -17,13 +16,14 @@ Only \*nix systems are supported at the moment.
 # Config
 
 The program expects your music to be in a directory given by the environment
-variable `MUSPLAY_MUSIC`. Playlists will be searched for in `$MUSPLAY_PLAYLISTS`
-or, if that is missing, in `$MUSPLAY_MUSIC/Playlists`.
+variable `MUSPLAY_MUSIC`. Playlists will be searched for in
+`$MUSPLAY_PLAYLISTS` or, if that is missing, in `$MUSPLAY_MUSIC/Playlists`.
 
 
 # Usage
 
 Throw the folder somewhere and run
+
 ```
 $ python3 musplay --help
 ```
@@ -31,11 +31,15 @@ $ python3 musplay --help
 
 # Search functionality
 
-If you only want to use the program to search for tracks, use the `-n` flag as in
+If you only want to use the program to search for tracks, use the `-n` flag as
+in
+
 ```
 $ python3 musplay -n '@Trash80'
 ```
+
 or run the `search.py` directly as in
+
 ```
 $ python3 musplay/search.py '@Trash80'
 ```

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Install
 
 This program requires Python 3.2+.
-It also requires the program `ag` (aka "The Silver Searcher") in your path.
 For music playback, it uses the program `mpv`.
-These can be installed on Mac OS X by using the following Homebrew command
+These can be installed on OS X by using the following
+[Homebrew](http://brew.sh/) command
 
 ```
-$ brew install python3 ag mpv
+$ brew install python3 mpv
 ```
 
 ### NOTE

--- a/play.py
+++ b/play.py
@@ -43,7 +43,7 @@ def play_tracks(paths, force_window=False, keep_open=False, shuffle=False,
     subprocess.run(cmd + ['--'] + paths)
 
 description = """
-Find and play music tracks using 'ag' (aka The Silver Searcher) and 'mpv'
+Find and play music tracks with 'mpv'.
 
 environment variables:
   MUSPLAY_MUSIC         where to find music tracks (required)

--- a/search.py
+++ b/search.py
@@ -1,9 +1,10 @@
 # 4 December 2015
-import subprocess
 import argparse
-import sys
 import os
 import re
+import shlex
+import subprocess
+import sys
 
 
 def error(*msg, code=1):
@@ -12,7 +13,7 @@ def error(*msg, code=1):
 
 
 extensions = {"mp3", "aac", "mka", "dts", "flac", "ogg", "m4a", "ac3", "opus", "wav"}
-_re_ext = r'(?:' + r'|'.join(extensions) + r')'
+_re_ext = r'(' + r'|'.join(extensions) + r')'
 
 
 def _patgen_title(query):
@@ -82,8 +83,8 @@ class Searcher:
             print("warning:", *msg, file=sys.stderr)
 
     def call_searcher(self, pattern, folder):
-        cmd = ['ag', '--nocolor', '-ig', pattern, '--', folder]
-        self.debug(' '.join(cmd))
+        cmd = ['find', '-Ef', folder, '--', '-iregex', '.*' + pattern + '.*']
+        self.debug(' '.join(shlex.quote(arg) for arg in cmd))
         result = subprocess.run(cmd, stdout=subprocess.PIPE)
 
         if result.returncode == 0:
@@ -180,7 +181,7 @@ class Searcher:
 
 
 description = """
-Find music tracks using 'ag' (aka The Silver Searcher)
+Find music tracks by track and album titles.
 
 environment variables:
   MUSPLAY_MUSIC         where to find music tracks (required)


### PR DESCRIPTION
The \*nix builtin program `find` has the functionality we need (path regex search), so we don't need to use `ag`. This makes `mpv` our only dependency (not counting Python).